### PR TITLE
Create dataset based on inference output JSON file

### DIFF
--- a/config/parameters.py
+++ b/config/parameters.py
@@ -12,15 +12,7 @@ class PipelineParams:
         self.task = "text-generation"
         self.torch_dtype = torch.bfloat16
         self.device_map = "auto"
-<<<<<<< HEAD
-<<<<<<< HEAD
         self.num_prompts = 2000
-=======
-        self.num_prompts = 100
->>>>>>> c9b4a54 (Adding support to generate the raw_results.json with WER measurement on each line.)
-=======
-        self.num_prompts = 6000
->>>>>>> cc4e230 (Cleanup)
         self.score_base = 9
         self.speaker_id = 10
 

--- a/config/parameters.py
+++ b/config/parameters.py
@@ -12,7 +12,11 @@ class PipelineParams:
         self.task = "text-generation"
         self.torch_dtype = torch.bfloat16
         self.device_map = "auto"
+<<<<<<< HEAD
         self.num_prompts = 2000
+=======
+        self.num_prompts = 100
+>>>>>>> c9b4a54 (Adding support to generate the raw_results.json with WER measurement on each line.)
         self.score_base = 9
         self.speaker_id = 10
 

--- a/config/parameters.py
+++ b/config/parameters.py
@@ -13,10 +13,14 @@ class PipelineParams:
         self.torch_dtype = torch.bfloat16
         self.device_map = "auto"
 <<<<<<< HEAD
+<<<<<<< HEAD
         self.num_prompts = 2000
 =======
         self.num_prompts = 100
 >>>>>>> c9b4a54 (Adding support to generate the raw_results.json with WER measurement on each line.)
+=======
+        self.num_prompts = 6000
+>>>>>>> cc4e230 (Cleanup)
         self.score_base = 9
         self.speaker_id = 10
 

--- a/src/reports_module.py
+++ b/src/reports_module.py
@@ -68,7 +68,6 @@ class Reporter:
         self.dump_info(summary, "results_summary", rep_folder)
         print("\n*\tReports can be viewed at: {}".format(rep_folder))
 
-
     def dump_info(self, output, name, path):
         with open(os.path.join(path, f"{name}.json"), "w") as file: # the as needs to be changed as it superseeds the dependency
             json.dump(output, file, indent=4)

--- a/src/reports_module.py
+++ b/src/reports_module.py
@@ -68,6 +68,7 @@ class Reporter:
         self.dump_info(summary, "results_summary", rep_folder)
         print("\n*\tReports can be viewed at: {}".format(rep_folder))
 
+
     def dump_info(self, output, name, path):
         with open(os.path.join(path, f"{name}.json"), "w") as file: # the as needs to be changed as it superseeds the dependency
             json.dump(output, file, indent=4)
@@ -102,7 +103,7 @@ class Reporter:
         progress_bar.close()
         return expected_responses, current_responses, responses_times, tokens_per_second
 
-    def calculate_wer(self, reference_texts, model_outputs, debug=False):
+    def calculate_wer(self, reference_texts, model_outputs):
         print("\n*\tCalculating WER")
         wer_windows = [100, 200, 250, 500, 1000, 2000, 2500, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000, 11000, 12000, 13000, 14000, 15000, 20000, 50000, 100000]
         wer_values = []
@@ -125,18 +126,19 @@ class Reporter:
                 upper_limit = w_next
                 wer_values.append(jiwer.wer(reference_texts[lower_limit:upper_limit], model_outputs[lower_limit:upper_limit],truth_transform=transforms,hypothesis_transform=transforms))
 
-        # for w in wer_windows:
-        #     if w < array_length:
-        #         wer_values.append(jiwer.wer(reference_texts[0:w], model_outputs[0:w],truth_transform=transforms,hypothesis_transform=transforms))
-
-        if debug:
-            print("\n*\tWER:")
-            index = 0
-            for w in wer_values:
-                print("{}-{}: {}".format(wer_windows[index], wer_windows[index+1], w))
-                index+=1
-
         return wer_values
+
+    def calculate_wer_per_line(self, reference_text, model_output):
+        transforms = jiwer.Compose([
+            jiwer.ExpandCommonEnglishContractions(),
+            jiwer.RemoveEmptyStrings(),
+            jiwer.ToLowerCase(),
+            jiwer.RemoveMultipleSpaces(),
+            jiwer.Strip(),
+            jiwer.RemovePunctuation(),
+            jiwer.ReduceToListOfListOfWords(),
+        ])
+        return jiwer.wer(reference_text, model_output, truth_transform=transforms, hypothesis_transform=transforms)
 
     def graphicate_results(self, x, y, x_desc, y_desc, title, file_path, display=False):
         print("\n*\tGenerating {} graphic".format(title))

--- a/src/run_model.py
+++ b/src/run_model.py
@@ -100,6 +100,7 @@ if __name__ == "__main__":
                 s.update({"response_time": transcription["response_time"]})
                 s.update({"tokens_per_second": transcription["tokens_per_seccond"]})
                 # s.update({"expected_response": s["expected_response"]})
+                s.update({"WER": Reporter(param).calculate_wer_per_line(reference_texts=s["expected_response"], model_outputs=transcription)})
                 progress_bar.update(1)
             progress_bar.close()
 

--- a/tools/create_dataset.py
+++ b/tools/create_dataset.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 #Example of usage:
-#./tools/create_dataset.py --input_path /root/botist/dataset/custom/wer_calculated_6k.json --dataset_name librispeech_asr --dataset_subset clean --dataset_split train.360
+#./tools/create_dataset.py --input_path /root/botist/datasets/custom/wer_calculated_6k.json --dataset_name librispeech_asr --dataset_subset clean --dataset_split train.360
 import json, argparse
 from datasets import load_dataset
 
 parser = argparse.ArgumentParser(description='Run model')
-parser.add_argument('--input_path', help='Where is located the json file to convert?', default="/root/botist/dataset/custom/wer_calculated_output_6k", required=True, type=str)
+parser.add_argument('--input_path', help='Where is located the json file to convert?', default="/root/botist/datasets/custom/wer_calculated_output_6k", required=True, type=str)
 parser.add_argument('--dataset_name', help='Dataset to be filtered', required=True, type=str)
 parser.add_argument('--dataset_subset', help='Subset of the dataset', required=True, type=str)
 parser.add_argument('--dataset_split', help='Split of the dataset', required=True, type=str)

--- a/tools/create_dataset.py
+++ b/tools/create_dataset.py
@@ -24,4 +24,5 @@ dataset = load_dataset(args["dataset_name"], args["dataset_subset"], split=args[
 #Filter by IDs
 filtered_dataset = dataset.filter(lambda ds: ds['id'] in filtered_ids)
 print(filtered_dataset)
-dataset.save_to_disk(args["output_path"])
+filtered_dataset.save_to_disk(args["output_path"])
+print("Saved dataset on: ", args['output_path'])

--- a/tools/create_dataset.py
+++ b/tools/create_dataset.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+#Example of usage:
+#./tools/create_dataset.py --input_path /root/botist/dataset/custom/wer_calculated_6k.json --dataset_name librispeech_asr --dataset_subset clean --dataset_split train.360
+import json, argparse
+from datasets import load_dataset
+
+parser = argparse.ArgumentParser(description='Run model')
+parser.add_argument('--input_path', help='Where is located the json file to convert?', default="/root/botist/dataset/custom/wer_calculated_output_6k", required=True, type=str)
+parser.add_argument('--dataset_name', help='Dataset to be filtered', required=True, type=str)
+parser.add_argument('--dataset_subset', help='Subset of the dataset', required=True, type=str)
+parser.add_argument('--dataset_split', help='Split of the dataset', required=True, type=str)
+parser.add_argument('--output_path', help='Folder to save the dataset on ./dataset', default="/root/botist/datasets/custom", required=False, type=str)
+parser.add_argument('--WER_threshold', help='Threshold', required=False, default=0.1, type=float)
+args = vars(parser.parse_args())
+
+# Read the JSON file
+with open(args["input_path"], 'r') as file: data = json.load(file)
+
+# Filter IDs by WER value
+filtered_ids = sorted([item["id"] for item in data if item.get('WER', float('inf')) <= args["WER_threshold"]])
+
+#Load dataset
+dataset = load_dataset(args["dataset_name"], args["dataset_subset"], split=args["dataset_split"])
+#Filter by IDs
+filtered_dataset = dataset.filter(lambda ds: ds['id'] in filtered_ids)
+print(filtered_dataset)
+dataset.save_to_disk(args["output_path"])


### PR DESCRIPTION
- Added script to filter and save dataset based on input WER values 
- Added example .json file to use the script
- Now raw_report.json also contains "WER" value per line. So you can use it as an input to the mentioned script.

Usage:
```
make bash

==========
== CUDA ==
==========

CUDA Version 12.1.1

Container image Copyright (c) 2016-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.

This container image and its contents are governed by the NVIDIA Deep Learning Container License.
By pulling and using the container, you accept the terms and conditions of this license:
https://developer.nvidia.com/ngc/nvidia-deep-learning-container-license

A copy of this license is made available in this container at /NGC-DL-CONTAINER-LICENSE for your convenience.

root@8fed56e95884:~/botist# ./tools/create_dataset.py --input_path /root/botist/datasets/custom/wer_calculated_6k.json --dataset_name librispeech_asr --dataset_subset clean --dataset_split train.360
/usr/local/lib/python3.10/dist-packages/datasets/load.py:1486: FutureWarning: The repository for librispeech_asr contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/librispeech_asr
You can avoid this message in future by passing the argument `trust_remote_code=True`.
Passing `trust_remote_code=True` will be mandatory to load this dataset from the next major release of `datasets`.
  warnings.warn(
Loading dataset shards: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 45/45 [00:00<00:00, 235048.17it/s]
Filter: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 104014/104014 [11:38<00:00, 148.97 examples/s]
Dataset({
    features: ['file', 'audio', 'text', 'speaker_id', 'chapter_id', 'id'],
    num_rows: 4598
})
Saving the dataset (3/3 shards): 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 4598/4598 [00:02<00:00, 1763.34 examples/s]
Saved dataset on:  /root/botist/datasets/custom
root@8fed56e95884:~/botist# 
```

Generated files:
![Screenshot from 2024-05-17 18-55-07](https://github.com/rafanog5521/botist/assets/95366589/efabbf41-84c5-4c77-9f73-7d08f167dbfd)
